### PR TITLE
fix: update example code

### DIFF
--- a/packages/client/example/index.js
+++ b/packages/client/example/index.js
@@ -1,19 +1,36 @@
-// import * as Name from 'w3name';
-// const Name = require('w3name');
 import * as Name from 'w3name'
+import { W3NameService } from 'w3name/service'
 
 async function createName() {
+  const service = W3NameService()
   const name = await Name.create()
   console.log('Name:', name.toString())
   // e.g. k51qzi5uqu5di9agapykyjh3tqrf7i14a7fjq46oo0f6dxiimj62knq13059lt
 
+  // The value that you want to publish in your record.
   const value = '/ipfs/bafkreiem4twkqzsq2aj4shbycd4yvoj2cx72vezicletlhi7dijjciqpui'
   const revision = await Name.v0(name, value)
-  console.log('revision', revision)
-  const res = await Name.publish(revision, name.key)
-  console.log('res', res)
+  console.log(`💿 Created new IPNS record /ipns/${name} => ${revision.value} (seqno ${revision.sequence})`)
+  console.log('⏳ Publishing to w3name...')
+  const res = await Name.publish(service, revision, name.key)
+  console.log(`✅ Done: ${res}`)
 
+  console.log('⏳ Resolving current value...')
+  const curRevision = await Name.resolve(service, name)
+  console.log(`👉 Current value: ${curRevision.value}\n`)
+
+  // Make a revision to our record to point to a new value
+  const nextValue = '/ipfs/bafybeiauyddeo2axgargy56kwxirquxaxso3nobtjtjvoqu552oqciudrm'
+  const nextRevision = await Name.increment(revision, nextValue)
+  console.log(`💿 Created new revision of IPNS record /ipns/${name} => ${nextRevision.value} (seqno ${nextRevision.sequence})`)
+
+  console.log('⏳ Publishing to w3name...')
+  await Name.publish(service, nextRevision, name.key)
+  console.log(`✅ Done: ${res}`)
+
+  console.log('⏳ Resolving current value...')
+  const newCurRevision = await Name.resolve(service, name)
+  console.log(`👉 Current value: ${newCurRevision.value}\n`)
 }
 
-createName();
-
+createName()


### PR DESCRIPTION
* Pass missing 'service' parameter
* Add steps showing how to revise a record

This is largely just porting over the example from [web3.storage/packages/client/examples/node.js/mutability.js](https://github.com/web3-storage/web3.storage/blob/9c287bb7c983d3adab6ebb304decb47c5093ad78/packages/client/examples/node.js/mutability.js) which I'm going to remove from that repo.