### PR TITLE
fix: rate limit publish and resolve reqs

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -212,9 +212,7 @@ export async function publish (revision: Revision, key: PrivateKey, service: W3N
     revision.sequence,
     new Date(revision.validity).getTime() - Date.now()
   )
-  if (service.rateLimiter) {
-    await service.rateLimiter()
-  }
+  await service.waitForRateLimit()
   await maybeHandleError(fetch(url.toString(), {
     method: 'POST',
     body: uint8ArrayToString(ipns.marshal(entry), 'base64pad')
@@ -226,9 +224,8 @@ export async function publish (revision: Revision, key: PrivateKey, service: W3N
  */
 export async function resolve (name: Name, service: W3NameService = defaultService): Promise<Revision> {
   const url = new URL(`name/${name.toString()}`, service.endpoint)
-  if (service.rateLimiter) {
-    await service.rateLimiter()
-  }
+  await service.waitForRateLimit()
+
   const res: globalThis.Response = await maybeHandleError(fetch(url.toString()))
   const { record } = await res.json()
 

--- a/packages/client/src/service.ts
+++ b/packages/client/src/service.ts
@@ -24,7 +24,7 @@ export default class W3NameService implements PublicService {
   waitForRateLimit: RateLimiter
 
   constructor (
-    endpoint: URL = new URL('https://api.web3.storage'),
+    endpoint: URL = new URL('https://name.web3.storage/'),
     waitForRateLimit: RateLimiter = createRateLimiter()
   ) {
     this.endpoint = endpoint

--- a/packages/client/src/service.ts
+++ b/packages/client/src/service.ts
@@ -21,13 +21,13 @@ function createRateLimiter () {
 
 export default class W3NameService implements PublicService {
   endpoint: URL
-  rateLimiter?: RateLimiter | undefined
+  waitForRateLimit: RateLimiter
 
   constructor (
     endpoint: URL = new URL('https://api.web3.storage'),
-    rateLimiter: RateLimiter | undefined = undefined
+    waitForRateLimit: RateLimiter = createRateLimiter()
   ) {
     this.endpoint = endpoint
-    this.rateLimiter = rateLimiter != null ? rateLimiter : createRateLimiter()
+    this.waitForRateLimit = waitForRateLimit
   }
 }

--- a/packages/client/test/name.spec.ts
+++ b/packages/client/test/name.spec.ts
@@ -122,18 +122,16 @@ describe('Name', () => {
       const value = '/ipfs/bafkreiem4twkqzsq2aj4shbycd4yvoj2cx72vezicletlhi7dijjciqpui'
       const revision = await Name.v0(name, value)
 
-      await Name.publish(service, revision, name.key)
+      await Name.publish(revision, name.key, service)
 
-      const resolved = await Name.resolve(service, name)
-
+      const resolved = await Name.resolve(name, service)
       assert.equal(resolved.value, revision.value)
 
       const newValue = '/ipfs/QmPFpDRC87jTdSYxjnEZUTjJuYF5yLRWxir3DzJ1XiVZ3t'
       const newRevision = await Name.increment(revision, newValue)
 
-      await Name.publish(service, newRevision, name.key)
-
-      const newResolved = await Name.resolve(service, name)
+      await Name.publish(newRevision, name.key, service)
+      const newResolved = await Name.resolve(name, service)
 
       assert.equal(newResolved.value, newRevision.value)
     })

--- a/packages/client/test/name.spec.ts
+++ b/packages/client/test/name.spec.ts
@@ -141,7 +141,7 @@ describe('Name', () => {
 
       try {
         // @ts-expect-error
-        await Name.resolve(service, name)
+        await Name.resolve(name, service)
 
         assert.unreachable()
       } catch (err: any) {
@@ -154,7 +154,7 @@ describe('Name', () => {
 
       try {
         // @ts-expect-error
-        await Name.resolve(service, name)
+        await Name.resolve(name, service)
 
         assert.unreachable()
       } catch (err: any) {

--- a/packages/e2e/test/e2e.spec.mjs
+++ b/packages/e2e/test/e2e.spec.mjs
@@ -24,7 +24,7 @@ describe('w3name module', () => {
   })
 
   after((done) => {
-    server.close() 
+    server.close()
     done()
   })
 
@@ -32,9 +32,9 @@ describe('w3name module', () => {
     const name = await Name.create()
     const value = '/ipfs/bafkreiem4twkqzsq2aj4shbycd4yvoj2cx72vezicletlhi7dijjciqpui'
     const revision = await Name.v0(name, value)
-    await Name.publish(service, revision, name.key)
+    await Name.publish(revision, name.key, service)
 
-    let latest = await Name.resolve(service, name)
+    let latest = await Name.resolve(name, service)
     assert.equal(latest.name, name)
     assert.equal(latest.value, value)
     assert.equal(latest.sequence, 0n)
@@ -42,9 +42,9 @@ describe('w3name module', () => {
 
     const value_2 = '/ipfs/bafkreid7fbwjx4swwewit5txzttoja4t4xnkj3rx3q7dlbj76gvixuq35y'
     const revision_2 = await Name.increment(revision, value_2)
-    await Name.publish(service, revision_2, name.key)
+    await Name.publish(revision_2, name.key, service)
 
-    latest = await Name.resolve(service, name)
+    latest = await Name.resolve(name, service)
     assert.equal(latest.name, name)
     assert.equal(latest.value, value_2)
     assert.equal(latest.sequence, 1n)


### PR DESCRIPTION
Add rate limiter awaits before requests are made in client `publish` and `resolve`. Make w3name service optional using a default service with a URL and RateLimiter.