### PR TITLE
fix: change GH workflows to run on all PR updates

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -7,8 +7,12 @@ on:
       - 'packages/api/**'
       - '.github/workflows/api.yml'
   pull_request:
-    branches:
-      - main
+    types:
+      - opened
+      # Triggered when a pull request's head branch is updated.
+      # For example, when the head branch is updated from the base branch, when new commits are pushed to the head branch, or when the base branch is changed.
+      - synchronize
+
     paths:
       - 'packages/api/**'
       - '.github/workflows/api.yml'

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -7,8 +7,11 @@ on:
       - 'packages/client/**'
       - '.github/workflows/client.yml'
   pull_request:
-    branches:
-      - main
+    types:
+      - opened
+      # Triggered when a pull request's head branch is updated.
+      # For example, when the head branch is updated from the base branch, when new commits are pushed to the head branch, or when the base branch is changed.
+      - synchronize
     paths:
       - 'packages/client/**'
       - '.github/workflows/client.yml'


### PR DESCRIPTION
After much experimentation, I have concluded that:

* The reason why the CI linting was flagging lines of code that didn't exist in the PR branch but only existed in `main` is because GH Actions does a prospective merge before running the scripts, so any issues in `main` show up in the CI run in the PR.
    * Now that we've fixed the linting issues in `main`, this isn't a problem.
* Removing `aegir` and replacing its linting with `standard` isn't worth the hassle (`aegir` is too tightly bound to various bits of the project setup, and other than parity with the web3.storage repo, we wouldn't gain much by switching).

So the only thing I've changed in this PR is the triggers, so that the CI should now run for any PR, even if it's merging into a feature branch rather than `main`. That's it. Long journey. Small PR.