### PR TITLE
chore: update READMEs (client, api, repo root)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,31 @@
 <h1 align="center">⁂<br/>w3name</h1>
 <p align="center">Content addressing for a dynamic web.</p>
 
-## Usage
+## About
 
-w3name is a service and client library that implements IPNS, which is a protocol that uses public key cryptography to allow for updatable naming in an atomically verifiable way. This means the service is trustless, since all updates can be verified to have come from the associated keypair.
+w3name is a service and client library that implements [IPNS](https://docs.ipfs.io/concepts/ipns/), which is a protocol that uses public key cryptography to allow for updatable naming in an atomically verifiable way. 
 
+Naming is famously one of the few hard problems in computer science, the exact number of which vary depending on the computer scientist you're speaking with and their predisposition to off-by-one errors.
 
-### Website
-TODO: Add website readme here!
+Naming can be especially difficult in distributed and decentralized systems, where you can't assume that everyone has the same view of the network, and there may not be any centralized "naming authorities" to resolve conflicts.
+
+IPNS works by using public key cryptography to allow "self-issued" names which don't require any coodination or central authorities. The caveat is that the definition of "name" is somewhat constrained compared to general-purpose key/value storage systems. 
+
+A "name" in the IPNS context is an identifier for a public key, or in some cases, an encoding of the public key itself. 
+
+To associate a value with the name, the holder of the corresponding private key creates a record containing the value and signs it with their private key. They then publish that record to an IPNS name service, such as the IPFS DHT or the w3name service.
+
+Anyone can query the service using the name and retrive the latest value, including everything needed to verify that the value was signed by the correct key and has not been altered since publication.
+
+<!-- TODO: include website readme once it has some content -->
 
 ### JS Client
 
-Use npm to install the [`w3name`]() module into your JS project, create an new w3name key with `Name.create()`, add a revision with `Name.v0({name}, {CID})` and publish the revision with `Name.publish({revision}, {key})`
+The `w3name` JavaScript client library provides a simple interface to the service API, as well as everything you need to create signing keys and records.
+
+The snippet below shows how to create an new w3name key with `Name.create()`, add a revision with `Name.v0({name}, {CID})` and publish the revision with `Name.publish({revision}, {key})`
+
+To use the library in your project, use npm or yarn to install the [`w3name`](https://www.npmjs.com/package/w3name) module.
 
 **node.js**
 ```js
@@ -27,12 +41,37 @@ await Name.publish(revision, name.key)
 
 See https://github.com/web3-storage/w3name/blob/main/packages/client/README.md for a guide to using the js client for the first time.
 
+You can also find a [how-to guide for working with the JS client](https://web3.storage/docs/how-tos/w3name/) included in the [Web3.Storage](https://web3.storage) documentation.
+
 ### cURL
 
-TODO: Add cURL instructions here!
+You can easily get the current value for any name by sending an HTTP request to `https://name.web3.storage/name/:key`, where `:key` is the name string. This will return a JSON object with the following shape:
 
-**See https://github.com/web3-storage/w3name/tree/main/packages/api for our complete documentation 📖🔍**
+```json
+{
+  "value": "the current value, as a string",
+  "record": "the full IPNS record for the current value, encoded to a binary form and base64pad encoded"
+}
+```
 
+Try pasting this into a terminal with `curl` installed:
+
+```shell
+curl https://name.web3.storage/name/k51qzi5uqu5dlcuzv5xhg1zqn48gobcvn2mx13uoig7zfj8rz6zvqdxsugka9z
+```
+
+You should see output similar to this:
+
+```json
+{
+  "value": "/ipfs/bafkreigbpn5osrexvl56ogyp5kivof2tmknkssk5odebqqeu23a22bcntu",
+  "record": "long base64 string, omitted for brevity..."
+}
+```
+
+**See https://github.com/web3-storage/w3name/tree/main/packages/api for documentation on other available API endpoints 📖🔍**
+
+<!-- TODO: add link to swagger api docs once published -->
 
 ## Building w3name
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ await Name.publish(revision, name.key)
 
 See https://github.com/web3-storage/w3name/blob/main/packages/client/README.md for a guide to using the js client for the first time.
 
+Full API reference doc for the JS client are available at https://web3-storage.github.io/w3name
+
 You can also find a [how-to guide for working with the JS client](https://web3.storage/docs/how-tos/w3name/) included in the [Web3.Storage](https://web3.storage) documentation.
 
 ### cURL

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -2,6 +2,61 @@
 
 The HTTP interface implemented as a Cloudflare Worker
 
+## API endpoints
+
+The API exposes the following endpoints.
+
+All endpoints return JSON objects for both successful responses and error conditions. In the event of an error, the response will have a non-200 status code, and the JSON response will include a `message` field with details about the error.
+
+### GET `/name/:key` - get the current record for a name
+
+Returns the current value for a given `:key`, where `:key` is a string-encoded name identifier, for example, `k51qzi5uqu5di9agapykyjh3tqrf7i14a7fjq46oo0f6dxiimj62knq13059lt`.
+
+On success, returns an object of the form:
+
+```json
+{
+  "value": "the current value, as a string",
+  "record": "the full IPNS record for the current value, encoded to a binary form and base64pad encoded"
+}
+```
+
+Will return a `404` status code if the requested key has not been published in the W3Name service. Note that keys published through other IPNS implementations will return a `404` from this endpoint, as it does not consult the IPFS DHT.
+
+### POST `/name/:key` - set the current value for a name
+
+Accepts a base64pad encoded IPNS record as the request body and sets it as the current value for the given `:key`, if the record is valid.
+
+The `:key` path parameter must be a valid string-encoded name identifier, for example, `k51qzi5uqu5di9agapykyjh3tqrf7i14a7fjq46oo0f6dxiimj62knq13059lt`.
+
+A record is considered valid if all of the following are true:
+
+- It contains an embedded public key that matches the public key embedded in the `:key` string
+- It contains a valid signature from the corresponding private key 
+- It has a validity date set to a time in the future
+
+Additionally, if there already exists a current record for the given name, the new record must meet one of the following criteria in order to overwrite the existing record:
+
+- The candidate record has a greater sequence number than the current record.
+- The sequence numbers are equal, but the candidate has a longer validity period than the current record.
+- Both the sequence number and validity period are equal, but the candidate record is longer than the current record.
+
+### GET `/name/:key/watch` - receive updates via websocket when new values are published to a name
+
+Watches the given `:key` for changes, pushing updated values onto a websocket as new records are published.
+
+To use this endpoint, your request must include an `Upgrade` header with the value set to `websocket`, and your client must be capable of handling a websocket upgrade response.
+
+When a new record is published, the websocket will receive an object with the following shape:
+
+```json
+{
+  "key": "the string-encoded name",
+  "value": "the latest value that was published, as a string",
+  "record": "the full IPNS record for the current value, encoded to a binary form and base64pad encoded"
+}
+```
+
 ## Getting started
 
 ### Tests

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -5,15 +5,56 @@
 
 Install the package using npm
 
-```console
+```bash
 npm install w3name
+```
+
+or yarn:
+
+```bash
+yarn add w3name
 ```
 
 ## Usage
 
+The `w3name` package exposes several "top-level" or module-scoped functions like `create`, `resolve`, and `publish`, along with a few classes like `Revision` and `Name` that are returned from and accepted by the API functions.
+
+In the examples below, the module is imported as `Name` using the ES module import syntax:
+
+```js
+import * as Name from 'w3name'
+```
+
+If you happen to already have something called `Name` in scope, you can choose a different identifier when importing, or simply import the functions you need:
+
+```js
+import { create, publish } from 'w3name'
+```
+
+
 ### Mutability
 
+w3name is an implementation of IPNS (the InterPlanetary Name System), which was designed to work with IPFS (the InterPlanetary File System). 
+
+IPFS allows you to uniquely identify any piece of data using a cryptographic hash of the data itself. This is known as [content addressing][w3storage-docs-content-addressing], and it's a very powerful and useful idea, especially when building distributed systems that span the planet (and ideally, beyond).
+
+One of the major constraints of a content-addressed system is that all such addresses are _immutable_, meaning that they can't be changed to refer to something else after they've been created.
+
+w3name and other IPNS implementations allow you to create _mutable_ references that can be updated over time, while still providing cryptographic verification that nothing has been tampered with.
+
+A "name" in the context of `w3name` is an identifier for a public key. The creator of the name can use their private key to publish records that will be returned when anyone fetches the latest value of the name. Because the name contains the verification key material, anyone can verify that the returned value was signed with the correct key and has not been tampered with since publication.
+
+Below are some examples of the main use cases for the w3name library. For more details, see the [library reference documentation][w3name-client-api-docs].
+
 #### Create and Publish
+
+The `create` function creates a new keypair, returing a `WritableName` object that can publish signed records to the w3name service.
+
+Once you've created a `WritableName`, you can create the initial `Revision`, which contains the value that you want to publish, along with some internal data like a sequence number to keep track of revisions.
+
+When creating the initial revision for a name, use the `v0` function. Subsequent revisions will use the `increment` function, as described in the [update](#update) section below.
+
+With a name and a revision in hand, you're ready to call `publish`, which signs the revision with your key and submits it to the w3name service.
 
 ```js
 import * as Name from 'w3name'
@@ -34,6 +75,10 @@ await Name.publish(revision, name.key)
 
 #### Resolve
 
+The `resolve` function retrieves the latest value for a name by sending a request to the w3name service.
+
+In the example below, we use the `parse` function to convert a string-encoded name into a `Name` object. Note that the `Name` returned by `parse` is not writable, unlike the `WritableName`s returned by `create`. As such, you can use `parse`d names to retrieve and verify values, but they are unable to create and update records.
+
 ```js
 import * as Name from 'w3name'
 
@@ -48,6 +93,8 @@ console.log('Resolved value:', revision.value)
 #### Update
 
 Updating records involves creating a new _revision_ from the previous one.
+
+When creating the initial revision, we used the `v0` function. All subsequent revisions must use the `increment` function, which accepts a `Revision` object describing the current state, and returns a new `Revision` with the new value and an incremented sequence number. Attempting to publish a new `Revision` with a sequence number thats less than or equal to the current value will result in an error.
 
 ```js
 import * as Name from 'w3name'
@@ -71,6 +118,10 @@ await Name.publish(nextRevision, name.key)
 #### Signing Key Management
 
 The private key used to sign IPNS records should be saved if a revision needs to be created in the future.
+
+The `WritableName` object returned by the `create` function has a `key` property containing the private signing key. Using `key.bytes`, we can obtain a `Uint8Array` filled with a binary representation of the private key, which can be saved to a safe location.
+
+Later, you can use the `from` function to convert from the binary representation to a `WritableName` object that can be used for signing and publication.
 
 ```js
 import * as Name from 'w3name'
@@ -113,3 +164,6 @@ await fs.promises.writeFile('ipns.revision', Revision.encode(rev))
 const bytes = await fs.promises.readFile('ipns.revision')
 const revision = Revision.decode(bytes)
 ```
+
+[w3storage-docs-content-addressing]: https://web3.storage/docs/concepts/content-addressing/
+[w3name-client-api-docs]: http://example.com/FIXME/replace-this-link-once-the-typedocs-are-published

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,5 +1,6 @@
 <h1 align="center">⁂<br/>w3name</h1>
-<p align="center">The JavaScript API client for <a href="https://github.com/web3-storage/w3name">W3Name</a></p>
+<p align="center">The JavaScript API client for <a href="https://web3.storage/products/w3name/">W3Name</a></p>
+
 
 ## Getting started
 
@@ -14,6 +15,8 @@ or yarn:
 ```bash
 yarn add w3name
 ```
+
+See [the getting started docs][w3storage-docs-w3name-getting-started] for more information.
 
 ## Usage
 
@@ -167,3 +170,4 @@ const revision = Revision.decode(bytes)
 
 [w3storage-docs-content-addressing]: https://web3.storage/docs/concepts/content-addressing/
 [w3name-client-api-docs]: http://example.com/FIXME/replace-this-link-once-the-typedocs-are-published
+[w3storage-docs-w3name-getting-started]: https://web3.storage/docs/how-tos/w3name/#getting-started

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -18,9 +18,11 @@ yarn add w3name
 
 See [the getting started docs][w3storage-docs-w3name-getting-started] for more information.
 
+You can also find full API reference documentation for the client at https://web3-storage.github.io/w3name
+
 ## Usage
 
-The `w3name` package exposes several "top-level" or module-scoped functions like `create`, `resolve`, and `publish`, along with a few classes like `Revision` and `Name` that are returned from and accepted by the API functions.
+The `w3name` package exposes several "top-level" or module-scoped functions like [`create`][typedoc-create], [`resolve`][typedoc-resolve], and [`publish`][typedoc-publish], along with a few classes like [`Revision`][typedoc-Revision] and [`Name`][typedoc-Name] that are returned from and accepted by the API functions.
 
 In the examples below, the module is imported as `Name` using the ES module import syntax:
 
@@ -51,13 +53,13 @@ Below are some examples of the main use cases for the w3name library.
 
 #### Create and Publish
 
-The `create` function creates a new keypair, returing a `WritableName` object that can publish signed records to the w3name service.
+The [`create`][typedoc-create] function creates a new keypair, returing a [`WritableName`][typedoc-WritableName] object that can publish signed records to the w3name service.
 
-Once you've created a `WritableName`, you can create the initial `Revision`, which contains the value that you want to publish, along with some internal data like a sequence number to keep track of revisions.
+Once you've created a [`WritableName`][typedoc-WritableName], you can create the initial [`Revision`][typedoc-Revision], which contains the value that you want to publish, along with some internal data like a sequence number to keep track of revisions.
 
-When creating the initial revision for a name, use the `v0` function. Subsequent revisions will use the `increment` function, as described in the [update](#update) section below.
+When creating the initial revision for a name, use the [`v0`][typedoc-v0] function. Subsequent revisions will use the [`increment`][typedoc-increment] function, as described in the [update](#update) section below.
 
-With a name and a revision in hand, you're ready to call `publish`, which signs the revision with your key and submits it to the w3name service.
+With a name and a revision in hand, you're ready to call [`publish`][typedoc-publish], which signs the revision with your key and submits it to the w3name service.
 
 ```js
 import * as Name from 'w3name'
@@ -78,9 +80,9 @@ await Name.publish(revision, name.key)
 
 #### Resolve
 
-The `resolve` function retrieves the latest value for a name by sending a request to the w3name service.
+The [`resolve`][typedoc-resolve] function retrieves the latest value for a name by sending a request to the w3name service.
 
-In the example below, we use the `parse` function to convert a string-encoded name into a `Name` object. Note that the `Name` returned by `parse` is not writable, unlike the `WritableName`s returned by `create`. As such, you can use `parse`d names to retrieve and verify values, but they are unable to create and update records.
+In the example below, we use the [`parse`][typedoc-parse] function to convert a string-encoded name into a [`Name`][typedoc-Name] object. Note that the [`Name`][typedoc-Name] returned by [`parse`][typedoc-parse] is not writable, unlike the [`WritableName`][typedoc-WritableName]s returned by [`create`][typedoc-create]. As such, you can use [`parse`][typedoc-parse]d names to retrieve and verify values, but they are unable to create and update records.
 
 ```js
 import * as Name from 'w3name'
@@ -97,7 +99,7 @@ console.log('Resolved value:', revision.value)
 
 Updating records involves creating a new _revision_ from the previous one.
 
-When creating the initial revision, we used the `v0` function. All subsequent revisions must use the `increment` function, which accepts a `Revision` object describing the current state, and returns a new `Revision` with the new value and an incremented sequence number. Attempting to publish a new `Revision` with a sequence number thats less than or equal to the current value will result in an error.
+When creating the initial revision, we used the [`v0`][typedoc-v0] function. All subsequent revisions must use the [`increment`][typedoc-increment] function, which accepts a [`Revision`][typedoc-Revision] object describing the current state, and returns a new [`Revision`][typedoc-Revision] with the new value and an incremented sequence number. Attempting to publish a new [`Revision`][typedoc-Revision] with a sequence number thats less than or equal to the current value will result in an error.
 
 ```js
 import * as Name from 'w3name'
@@ -122,9 +124,9 @@ await Name.publish(nextRevision, name.key)
 
 The private key used to sign IPNS records should be saved if a revision needs to be created in the future.
 
-The `WritableName` object returned by the `create` function has a `key` property containing the private signing key. Using `key.bytes`, we can obtain a `Uint8Array` filled with a binary representation of the private key, which can be saved to a safe location.
+The [`WritableName`][typedoc-WritableName] object returned by the [`create`][typedoc-create] function has a `key` property containing the private signing key. Using `key.bytes`, we can obtain a `Uint8Array` filled with a binary representation of the private key, which can be saved to a safe location.
 
-Later, you can use the `from` function to convert from the binary representation to a `WritableName` object that can be used for signing and publication.
+Later, you can use the [`from`][typedoc-from] function to convert from the binary representation to a [`WritableName`][typedoc-WritableName] object that can be used for signing and publication.
 
 ```js
 import * as Name from 'w3name'
@@ -170,3 +172,15 @@ const revision = Revision.decode(bytes)
 
 [w3storage-docs-content-addressing]: https://web3.storage/docs/concepts/content-addressing/
 [w3storage-docs-w3name-getting-started]: https://web3.storage/docs/how-tos/w3name/#getting-started
+
+[typedoc-create]: https://web3-storage.github.io/w3name/functions/create.html
+[typedoc-from]: https://web3-storage.github.io/w3name/functions/from.html
+[typedoc-increment]: https://web3-storage.github.io/w3name/functions/increment.html
+[typedoc-parse]: https://web3-storage.github.io/w3name/functions/parse.html
+[typedoc-publish]: https://web3-storage.github.io/w3name/functions/publish.html
+[typedoc-resolve]: https://web3-storage.github.io/w3name/functions/resolve.html
+[typedoc-v0]: https://web3-storage.github.io/w3name/functions/v0.html
+
+[typedoc-Name]: https://web3-storage.github.io/w3name/classes/Name.html
+[typedoc-WritableName]: https://web3-storage.github.io/w3name/classes/WritableName.html
+[typedoc-Revision]: https://web3-storage.github.io/w3name/classes/Revision.html

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -47,7 +47,7 @@ w3name and other IPNS implementations allow you to create _mutable_ references t
 
 A "name" in the context of `w3name` is an identifier for a public key. The creator of the name can use their private key to publish records that will be returned when anyone fetches the latest value of the name. Because the name contains the verification key material, anyone can verify that the returned value was signed with the correct key and has not been tampered with since publication.
 
-Below are some examples of the main use cases for the w3name library. For more details, see the [library reference documentation][w3name-client-api-docs].
+Below are some examples of the main use cases for the w3name library. 
 
 #### Create and Publish
 
@@ -169,5 +169,4 @@ const revision = Revision.decode(bytes)
 ```
 
 [w3storage-docs-content-addressing]: https://web3.storage/docs/concepts/content-addressing/
-[w3name-client-api-docs]: http://example.com/FIXME/replace-this-link-once-the-typedocs-are-published
 [w3storage-docs-w3name-getting-started]: https://web3.storage/docs/how-tos/w3name/#getting-started


### PR DESCRIPTION
This adds a bit of context to some of the example snippets in the client README.

TODO:

- [x] update link to API docs

Also TODO, but possibly in a separate PR:
- [x] add overview of routes to `packages/api/README.md`
- [x] update main monorepo README
  - [x] wrap up remaining TODOs in the text
  - [x] add quick intro / links to IPNS docs, etc
