### PR TITLE
feat: Added ipns publishing via HTTP

### DIFF
--- a/packages/api/src/name.ts
+++ b/packages/api/src/name.ts
@@ -10,7 +10,7 @@ import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { validate as ipnsValidate } from 'ipns/validator'
 import * as Digest from 'multiformats/hashes/digest'
 import * as ipns from 'ipns'
-import type { Env } from '.'
+import type { Env } from './env'
 import type { IPNSRecordData } from './record'
 
 const libp2pKeyCode = 0x72
@@ -106,7 +106,7 @@ export async function namePost (request: Request, env: Env, ctx: ExecutionContex
       throw new HTTPError('embedded public key mismatch', 400)
     }
 
-    const recordData = {
+    const recordData: IPNSRecordData = {
       key, // base36 "libp2p-key" encoding of the public key
       record, // the serialized IPNS record - base64 encoded
       hasV2Sig: Boolean(entry.signatureV2),
@@ -131,6 +131,18 @@ export async function namePost (request: Request, env: Env, ctx: ExecutionContex
         ctx.waitUntil((async () => {
           await NameRoom.broadcast(request, env.NAME_ROOM, key, broadcastData)
           await NameRoom.broadcast(request, env.NAME_ROOM, '*', broadcastData)
+          const response = await fetch(env.PUBLISHER_ENDPOINT_URL, {
+            method: 'POST',
+            body: JSON.stringify(recordData),
+            headers: {
+              Authorization: env.PUBLISHER_AUTH_SECRET
+            }
+          })
+
+          if (response.ok !== true) {
+            throw new Error(`Error when publishing to the IPNS Publisher endpoint`)
+          }
+
         })())
         return jsonResponse(JSON.stringify({ id: key }), 202)
       } else {

--- a/packages/api/src/name.ts
+++ b/packages/api/src/name.ts
@@ -139,10 +139,9 @@ export async function namePost (request: Request, env: Env, ctx: ExecutionContex
             }
           })
 
-          if (response.ok !== true) {
-            throw new Error(`Error when publishing to the IPNS Publisher endpoint`)
+          if (!response.ok) {
+            throw new Error('Error when publishing to the IPNS Publisher endpoint')
           }
-
         })())
         return jsonResponse(JSON.stringify({ id: key }), 202)
       } else {

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -16,6 +16,12 @@ new_classes = ["NameRoom0", "IPNSRecord"]
     { name = "IPNS_RECORD", class_name = "IPNSRecord" }
   ]
 
+
+[vars]
+REBROADCAST_INTERVAL_MS = "600000"
+PUBLISHER_ENDPOINT_URL = "http://127.0.0.1:8000"
+PUBLISHER_AUTH_SECRET = "123456"
+
 # Test
 
 [env.test.vars]


### PR DESCRIPTION
Resolved #44 

Preserves the websocket broadcasting but adds publishing the IPNS record via HTTP to the IPNS publisher endpoint