### PR TITLE
fix: Add correct schemas for openAPI.

### DIFF
--- a/packages/api/swagger-config.json
+++ b/packages/api/swagger-config.json
@@ -1,171 +1,183 @@
 {
-  "openapi":"3.0.2",
-  "info":{
-     "title":"W3Name API",
-     "description":"This documentation describes the HTTP API for [**W3name**](https://name.web3.storage), which allows you to build applications to create and manage [IPNS records](https://docs.ipfs.tech/concepts/ipns/).\n\nYou can also interact with this API using client libraries. See [**W3Name Client package**](https://www.npmjs.com/package/w3name) for more information on using a client library.\n\n## API endpoint URL\n\nThe main public API endpoint URL for W3Name is `https://name.web3.storage`. All endpoints described in this document should be made relative to this root URL. For example, to post to the `/name/:key` endpoint, send your request to `https://name.web3.storage/name/:key`.",
-     "version":"1.0"
-  },
-  "servers":[
-     {
-        "url":"https://name.web3.storage"
-     }
-  ],
-  "tags":[
-     {
-        "name":"W3Name HTTP API"
-     }
-  ],
-  "paths":{
-     "/name/{key}":{
-        "post":{
-           "tags":[
-              "W3Name HTTP API"
-           ],
-           "summary":"Upload a record",
-           "description":"Upload a name record\n\nNote that only one record can be uploaded at a time.",
-           "operationId":"post-name",
-           "requestBody":{
-              "required":true,
-              "content":{
-                 "text/plain":{
-                    "schema":{
-                       "type":"string",
-                       "format":"binary"
-                    }
-                 },
-                 "application/octet-stream":{
-                    "schema":{
-                       "type":"string",
-                       "format":"binary"
-                    }
-                 }
-              }
-           },
-           "parameters":[
-              {
-                 "name":"key",
-                 "in":"path",
-                 "required":true,
-                 "schema":{
-                    "$ref":"#/components/schemas/Key"
-                 }
-              }
-           ],
-           "responses":{
-              "200":{
-                 "description":"OK",
-                 "content":{
-                    "application/json":{
-                       "schema":{
-                          "$ref":"#/components/schemas/Record"
-                       }
-                    }
-                 }
-              },
-              "400":{
-                 "$ref":"#/components/responses/badRequest"
-              },
-              "5XX":{
-                 "$ref":"#/components/responses/internalServerError"
-              }
-           }
-        },
-        "get":{
-           "tags":[
-              "W3Name HTTP API"
-           ],
-           "summary":"Retrieve a record",
-           "description":"Retrieve an IPNS Record.",
-           "operationId":"get-record",
-           "security":[
-
-           ],
-           "parameters":[
-              {
-                 "name":"key",
-                 "in":"path",
-                 "required":true,
-                 "schema":{
-                    "$ref":"#/components/schemas/Key"
-                 }
-              }
-           ],
-           "responses":{
-              "200":{
-                 "description":"OK",
-                 "content":{
-                    "application/json":{
-                       "schema":{
-                          "$ref":"#/components/schemas/Record"
-                       }
-                    }
-                 }
-              },
-              "400":{
-                 "$ref":"#/components/responses/badRequest"
-              },
-              "5XX":{
-                 "$ref":"#/components/responses/internalServerError"
-              }
-           }
-        }
-     }
-  },
-  "components":{
-     "schemas":{
-        "Record":{
-           "type":"string",
-           "example":"CkEvaXBmcy9iYWZrcmVpZW00dHdrcXpzcTJhajRzaGJ5Y2Q0eXZvajJjeDcydmV6aWNsZXRsaGk3ZGlqamNpcXB1aRJAjJy/lm/jZH1sxmHCiM4FGXYsqUB/SgBHoTFIE5edwc+qy+pCDgZJbh1k7we7MvA1gzpepLCyzfWWa7KKzWAkARgAIh4yMDIzLTA3LTA1VDExOjE5OjA3LjM3NzAwMDAwMFooADDg8oe+64XNBUJAGpFQ13lB9M/XiWLbQKi/XZRk7MlPWNWFJHemPaPXkzce0ZWltbn7T1VN2pSONpfJWa5eSR5LgPggm5Zzzb6OAEqYAaVjVFRMGwALNC63wflgZVZhbHVlWEEvaXBmcy9iYWZrcmVpZW00dHdrcXpzcTJhajRzaGJ5Y2Q0eXZvajJjeDcydmV6aWNsZXRsaGk3ZGlqamNpcXB1aWhTZXF1ZW5jZQBoVmFsaWRpdHlYHjIwMjMtMDctMDVUMTE6MTk6MDcuMzc3MDAwMDAwWmxWYWxpZGl0eVR5cGUAbafkreidivzimqfqtoqxkrpge6bjyhlvxqs3rhe73owtmdulaxr5do5in7u",
-           "description":"an IPNS Record."
-        },
-        "Key":{
-           "type":"string",
-           "example":"k51qzi5uqu5dgsc1bvsuk1x84bptdvp8cupbnnbqxpxzd629gadpci3kpcm311",
-           "description":"a public key for a given record."
-        },
-        "ErrorResponse":{
-           "type":"object",
-           "properties":{
-              "name":{
-                 "type":"string"
-              },
-              "message":{
-                 "type":"string"
-              }
-           }
-        }
-     },
-     "responses":{
-        "notFound":{
-           "description":"Not Found",
-           "content":{
-              "application/json":{
-                 "schema":{
-                    "$ref":"#/components/schemas/ErrorResponse"
-                 }
-              }
-           }
-        },
-        "internalServerError":{
-           "description":"Internal Server Error",
-           "content":{
-              "application/json":{
-                 "schema":{
-                    "$ref":"#/components/schemas/ErrorResponse"
-                 }
-              }
-           }
-        },
-        "badRequest":{
-           "description":"Bad Request",
-           "content":{
-              "application/json":{
-                 "schema":{
-                    "$ref":"#/components/schemas/ErrorResponse"
-                 }
-              }
-           }
-        }
-     }
-  }
+   "openapi": "3.0.2",
+   "info": {
+      "title": "W3Name API",
+      "description": "This documentation describes the HTTP API for [**W3name**](https://name.web3.storage), which allows you to build applications to create and manage [IPNS records](https://docs.ipfs.tech/concepts/ipns/).\n\nYou can also interact with this API using client libraries. See [**W3Name Client package**](https://www.npmjs.com/package/w3name) for more information on using a client library.\n\n## API endpoint URL\n\nThe main public API endpoint URL for W3Name is `https://name.web3.storage`. All endpoints described in this document should be made relative to this root URL. For example, to post to the `/name/:key` endpoint, send your request to `https://name.web3.storage/name/:key`.",
+      "version": "1.0"
+   },
+   "servers": [
+      {
+         "url": "https://name.web3.storage"
+      }
+   ],
+   "tags": [
+      {
+         "name": "W3Name HTTP API"
+      }
+   ],
+   "paths": {
+      "/name/{key}": {
+         "post": {
+            "tags": [
+               "W3Name HTTP API"
+            ],
+            "summary": "Upload a record",
+            "description": "Upload a name record\n\nNote that only one record can be uploaded at a time.",
+            "operationId": "post-name",
+            "requestBody": {
+               "required": true,
+               "content": {
+                  "text/plain": {
+                     "schema": {
+                        "type": "string"
+                     }
+                  },
+                  "application/octet-stream": {
+                     "schema": {
+                        "type": "string",
+                        "format": "binary"
+                     }
+                  }
+               }
+            },
+            "parameters": [
+               {
+                  "name": "key",
+                  "in": "path",
+                  "required": true,
+                  "schema": {
+                     "$ref": "#/components/schemas/Key"
+                  }
+               }
+            ],
+            "responses": {
+               "202": {
+                  "description": "OK",
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/Id"
+                        }
+                     }
+                  }
+               },
+               "400": {
+                  "$ref": "#/components/responses/badRequest"
+               },
+               "5XX": {
+                  "$ref": "#/components/responses/internalServerError"
+               }
+            }
+         },
+         "get": {
+            "tags": [
+               "W3Name HTTP API"
+            ],
+            "summary": "Retrieve a record",
+            "description": "Retrieve an IPNS Record.",
+            "operationId": "get-record",
+            "security": [],
+            "parameters": [
+               {
+                  "name": "key",
+                  "in": "path",
+                  "required": true,
+                  "schema": {
+                     "$ref": "#/components/schemas/Key"
+                  }
+               }
+            ],
+            "responses": {
+               "200": {
+                  "description": "OK",
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/Record"
+                        }
+                     }
+                  }
+               },
+               "400": {
+                  "$ref": "#/components/responses/badRequest"
+               },
+               "5XX": {
+                  "$ref": "#/components/responses/internalServerError"
+               }
+            }
+         }
+      }
+   },
+   "components": {
+      "schemas": {
+         "Id": {
+            "type": "object",
+            "properties": {
+               "id": {
+                  "$ref": "#/components/schemas/Key"
+               }
+            },
+            "description": "The published IPNS Key that will rersolve the record once it has persisted to th DHT."
+         },
+         "Record": {
+            "type": "object",
+            "properties": {
+               "value": {
+                  "type": "string",
+                  "example": "/ipfs/QmPqrEHJTex2CPbqNULCmbSFJT3boBwAAfMb5UjvXtKjEe"
+               },
+               "record": {
+                  "type": "string",
+                  "example": "CjQvaXBmcy9RbVBxckVISlRleDJDUGJxTlVMQ21iU0ZKVDNib0J3QUFmTWI1VWp2WHRLakVlEkB/s3F4iHVMyA9LOFizt5N4PHiI2APD15wsMa1RXGwmugThVpUjTw+5HHwFt16TI/8AKk/1p8+26hylxMxd3wAIGAAiHjIwMjMtMDgtMDVUMDk6NDk6MjguNDk5MDAwMDAwWigNMODyh77rhc0FQkCdgM1u1AAUsdf4pE7/kNYjl438/g6Ja48Tr2evFSRc6YSMgljaKX8PpQC0JDlZqF2jiKdHRUOaxLHArPo9MW0PSosBpWNUVEwbAAs0LrfB+WBlVmFsdWVYNC9pcGZzL1FtUHFyRUhKVGV4MkNQYnFOVUxDbWJTRkpUM2JvQndBQWZNYjVVanZYdEtqRWVoU2VxdWVuY2UNaFZhbGlkaXR5WB4yMDIzLTA4LTA1VDA5OjQ5OjI4LjQ5OTAwMDAwMFpsVmFsaWRpdHlUeXBlAA=="
+               }
+            },
+            "description": "an IPNS Record and value."
+         },
+         "Key": {
+            "type": "string",
+            "example": "k51qzi5uqu5dgsc1bvsuk1x84bptdvp8cupbnnbqxpxzd629gadpci3kpcm311",
+            "description": "a public key for a given record."
+         },
+         "ErrorResponse": {
+            "type": "object",
+            "properties": {
+               "message": {
+                  "type": "string"
+               }
+            }
+         }
+      },
+      "responses": {
+         "notFound": {
+            "description": "Not Found",
+            "content": {
+               "application/json": {
+                  "schema": {
+                     "$ref": "#/components/schemas/ErrorResponse"
+                  }
+               }
+            }
+         },
+         "internalServerError": {
+            "description": "Internal Server Error",
+            "content": {
+               "application/json": {
+                  "schema": {
+                     "$ref": "#/components/schemas/ErrorResponse"
+                  }
+               }
+            }
+         },
+         "badRequest": {
+            "description": "Bad Request",
+            "content": {
+               "application/json": {
+                  "schema": {
+                     "$ref": "#/components/schemas/ErrorResponse"
+                  }
+               }
+            }
+         }
+      }
+   }
 }

--- a/packages/api/swagger-config.json
+++ b/packages/api/swagger-config.json
@@ -117,7 +117,7 @@
                   "$ref": "#/components/schemas/Key"
                }
             },
-            "description": "The published IPNS Key that will rersolve the record once it has persisted to th DHT."
+            "description": "The published IPNS Key that will rersolve to the record once it has persisted to the DHT."
          },
          "Record": {
             "type": "object",
@@ -131,12 +131,12 @@
                   "example": "CjQvaXBmcy9RbVBxckVISlRleDJDUGJxTlVMQ21iU0ZKVDNib0J3QUFmTWI1VWp2WHRLakVlEkB/s3F4iHVMyA9LOFizt5N4PHiI2APD15wsMa1RXGwmugThVpUjTw+5HHwFt16TI/8AKk/1p8+26hylxMxd3wAIGAAiHjIwMjMtMDgtMDVUMDk6NDk6MjguNDk5MDAwMDAwWigNMODyh77rhc0FQkCdgM1u1AAUsdf4pE7/kNYjl438/g6Ja48Tr2evFSRc6YSMgljaKX8PpQC0JDlZqF2jiKdHRUOaxLHArPo9MW0PSosBpWNUVEwbAAs0LrfB+WBlVmFsdWVYNC9pcGZzL1FtUHFyRUhKVGV4MkNQYnFOVUxDbWJTRkpUM2JvQndBQWZNYjVVanZYdEtqRWVoU2VxdWVuY2UNaFZhbGlkaXR5WB4yMDIzLTA4LTA1VDA5OjQ5OjI4LjQ5OTAwMDAwMFpsVmFsaWRpdHlUeXBlAA=="
                }
             },
-            "description": "an IPNS Record and value."
+            "description": "an IPNS Record."
          },
          "Key": {
             "type": "string",
             "example": "k51qzi5uqu5dgsc1bvsuk1x84bptdvp8cupbnnbqxpxzd629gadpci3kpcm311",
-            "description": "a public key for a given record."
+            "description": "A string representation of a public key, which is the 'name' that can be resolved to a record."
          },
          "ErrorResponse": {
             "type": "object",


### PR DESCRIPTION
Corrects the schemas for the Swagger UI
This just documents the two HTTP endpoints for posting and retrieving /name/{key} records.