### PR TITLE
chore: switch to org-level GH secret for Cloudflare token

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -53,7 +53,7 @@ jobs:
           # SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN}}
           # SENTRY_UPLOAD: ${{ secrets.SENTRY_UPLOAD}}
         with:
-          apiToken: ${{ secrets.CF_API_TOKEN }}
+          apiToken: ${{ secrets.CF_TOKEN }}
           workingDirectory: 'packages/api'
           environment: 'staging'
       - name: Test publish a record to staging
@@ -94,6 +94,6 @@ jobs:
           # SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN}}
           # SENTRY_UPLOAD: ${{ secrets.SENTRY_UPLOAD}}
         with:
-          apiToken: ${{ secrets.CF_API_TOKEN }}
+          apiToken: ${{ secrets.CF_TOKEN }}
           workingDirectory: 'packages/api'
           environment: 'production'


### PR DESCRIPTION
Once this is merged, the `CF_API_TOKEN` secret can (and should) be deleted from this repo's secrets.