### PR TITLE
Manually set new version

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -44,6 +44,8 @@ jobs:
           monorepo-tags: true
           package-name: w3name
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Other Changes","hidden":false}]'
+          release-as: '1.0.5'
+          last-release-sha: d74d9f9566d2641421db1095fbb969929d14f4ff
       - uses: actions/checkout@v2
         if: ${{ steps.tag-release.outputs.releases_created }}
       - uses: actions/setup-node@v2


### PR DESCRIPTION
Manually set package version number. w3name was manually released before implementing release-please. This PR will make sure version numbers are in sync. This will be undone in another PR.