### PR TITLE
fix: use esbuild global values correctly

### DIFF
--- a/packages/api/src/env.ts
+++ b/packages/api/src/env.ts
@@ -37,7 +37,7 @@ export function envAll (req: Request, env: Env, ctx: ExecutionContext) {
         })
       },
       environment: env.ENV,
-      release: env.SENTRY_RELEASE,
+      release: SENTRY_RELEASE,
       pkg
     })
     : undefined
@@ -50,8 +50,8 @@ export function envAll (req: Request, env: Env, ctx: ExecutionContext) {
     token: env.LOGTAIL_TOKEN,
     debug: env.DEBUG === 'true',
     sentry: env.sentry,
-    version: env.VERSION,
-    branch: env.BRANCH,
-    commithash: env.COMMITHASH
+    version: VERSION,
+    branch: BRANCH,
+    commithash: COMMITHASH
   })
 }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -6,6 +6,14 @@ import { addCorsHeaders, withCorsHeaders, corsOptions } from './cors'
 import * as swaggerConfig from './swaggerConfig'
 import { Env, envAll } from './env'
 
+declare global {
+  // These must be defined as parameters to esbuild.build() in buildworkermodule.js
+  var BRANCH: string
+  var COMMITHASH: string
+  var SENTRY_RELEASE: string
+  var VERSION: string
+}
+
 const router = Router()
 
 router.all('*', envAll)


### PR DESCRIPTION
Values passed in the 'define' options to esbuild become global variables, not environment variables. See: https://esbuild.github.io/api/#define

This should fix the problem of the invalid `release` string being passed to Sentry, as described in #86.