### PR TITLE
fix: create name from raw encoded key

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -124,7 +124,7 @@ await Name.publish(nextRevision, name.key)
 
 The private key used to sign IPNS records should be saved if a revision needs to be created in the future.
 
-The [`WritableName`][typedoc-WritableName] object returned by the [`create`][typedoc-create] function has a `key` property containing the private signing key. Using `key.bytes`, we can obtain a `Uint8Array` filled with a binary representation of the private key, which can be saved to a safe location.
+The [`WritableName`][typedoc-WritableName] object returned by the [`create`][typedoc-create] function has a `key` property containing the private signing key. Using `key.raw`, we can obtain a `Uint8Array` filled with a binary representation of the private key, which can be saved to a safe location.
 
 Later, you can use the [`from`][typedoc-from] function to convert from the binary representation to a [`WritableName`][typedoc-WritableName] object that can be used for signing and publication.
 
@@ -136,7 +136,7 @@ import fs from 'fs'
 const name = await Name.create()
 
 // Store the signing key to a file for use later
-await fs.promises.writeFile('priv.key', name.key.bytes)
+await fs.promises.writeFile('priv.key', name.key.raw)
 
 // ...later
 

--- a/packages/client/test/name.spec.ts
+++ b/packages/client/test/name.spec.ts
@@ -165,4 +165,19 @@ describe('Name', () => {
       }
     })
   })
+
+  describe('private key management', () => {
+    it('round trips protobuf encoded key', async () => {
+      const name0 = await Name.create()
+      const skBytes = keys.privateKeyToProtobuf(name0.key)
+      const name1 = await Name.from(skBytes)
+      assert.equal(name1.toString(), name0.toString())
+    })
+
+    it('round trips raw encoded key', async () => {
+      const name0 = await Name.create()
+      const name1 = await Name.from(name0.key.raw)
+      assert.equal(name1.toString(), name0.toString())
+    })
+  })
 })


### PR DESCRIPTION
The `PrivateKey` interface had a breaking change where it no longer exposed the protobuf encoded key. This PR allows the raw bytes (available as `.raw` on the `PrivateKey` type) to be used instead, so that users don't have to install `@libp2p/crypto` and encode as protobuf.